### PR TITLE
Update templates with 12.8.4 AMI IDs

### DIFF
--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -192,43 +192,43 @@ Mappings:
     AMI:
       OEDBAMZNLINUX2: Amazon Linux 2 AMI with OpenEdge Database
     af-south-1:
-      OEDBAMZNLINUX2: ami-02b75f15c4cef540b
+      OEDBAMZNLINUX2: ami-09ce20bd4810480a1
     ap-east-1:
-      OEDBAMZNLINUX2: ami-0e7f1dfd20e0231c3
+      OEDBAMZNLINUX2: ami-0b739bd85484ac94c
     ap-northeast-1:
-      OEDBAMZNLINUX2: ami-085a33252f1fee74e
+      OEDBAMZNLINUX2: ami-0c78d0cc2a2839aec
     ap-northeast-2:
-      OEDBAMZNLINUX2: ami-063b65912dda0e599
+      OEDBAMZNLINUX2: ami-068077c191bed032c
     ap-south-1:
-      OEDBAMZNLINUX2: ami-0bcf9f77667f96966
+      OEDBAMZNLINUX2: ami-0e5a942f05a621418
     ap-southeast-1:
-      OEDBAMZNLINUX2: ami-07f9924758aab9a9f
+      OEDBAMZNLINUX2: ami-05215ac269a71e800
     ap-southeast-2:
-      OEDBAMZNLINUX2: ami-0193dcf39b9412dc0
+      OEDBAMZNLINUX2: ami-0dd18b69f2d988290
     ca-central-1:
-      OEDBAMZNLINUX2: ami-0931351a82f0fafcf
+      OEDBAMZNLINUX2: ami-03a65216ae7bc6206
     eu-central-1:
-      OEDBAMZNLINUX2: ami-0f57299ef84865a60
+      OEDBAMZNLINUX2: ami-0fe1bf999cff256ae
     eu-north-1:
-      OEDBAMZNLINUX2: ami-0eb6d8e034c3b26c9
+      OEDBAMZNLINUX2: ami-04cc80044c1d1a4d8
     eu-south-1:
-      OEDBAMZNLINUX2: ami-005303d2d2ca3b842
+      OEDBAMZNLINUX2: ami-0b71439fbd51761c5
     eu-west-1:
-      OEDBAMZNLINUX2: ami-064aba9f09a2f0773
+      OEDBAMZNLINUX2: ami-0fa75e0dcebdf1bee
     eu-west-2:
-      OEDBAMZNLINUX2: ami-09c70c861bd6b80b0
+      OEDBAMZNLINUX2: ami-0d41906dadd81ae38
     eu-west-3:
-      OEDBAMZNLINUX2: ami-0e4dfcd87921f1198
+      OEDBAMZNLINUX2: ami-0b8e8892c83f76b51
     sa-east-1:
-      OEDBAMZNLINUX2: ami-0f1f1431655455b8d
+      OEDBAMZNLINUX2: ami-0e88ebe08ffd40f47
     us-east-1:
-      OEDBAMZNLINUX2: ami-079ae64665ebf4925
+      OEDBAMZNLINUX2: ami-00e1934b96fd35d5d
     us-east-2:
-      OEDBAMZNLINUX2: ami-01bb7ffe18ddf4fe3
+      OEDBAMZNLINUX2: ami-0e799d9d986ceadad
     us-west-1:
-      OEDBAMZNLINUX2: ami-0bc216181300e667e
+      OEDBAMZNLINUX2: ami-04e14495ff1f985de
     us-west-2:
-      OEDBAMZNLINUX2: ami-0c99cc3a6bede73e6
+      OEDBAMZNLINUX2: ami-00663e544f8461061
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -208,43 +208,43 @@ Mappings:
     AMI:
       PASOEAMZNLINUX2: Amazon Linux 2 AMI with PAS for OpenEdge
     af-south-1:
-      PASOEAMZNLINUX2: ami-0c281b154dd811948
+      PASOEAMZNLINUX2: ami-07fa6c7fa54967647
     ap-east-1:
-      PASOEAMZNLINUX2: ami-0b61a0507f9c4b3dc
+      PASOEAMZNLINUX2: ami-003ae745b83686e43
     ap-northeast-1:
-      PASOEAMZNLINUX2: ami-09532d784a4b748f6
+      PASOEAMZNLINUX2: ami-0ddbc953750b5ed6a
     ap-northeast-2:
-      PASOEAMZNLINUX2: ami-04f9062f218e2e470
+      PASOEAMZNLINUX2: ami-0a028d4deb9762094
     ap-south-1:
-      PASOEAMZNLINUX2: ami-07955cfec4b6e87ad
+      PASOEAMZNLINUX2: ami-052bf52322506e6f7
     ap-southeast-1:
-      PASOEAMZNLINUX2: ami-0cd5f8a8496a1901c
+      PASOEAMZNLINUX2: ami-0379eb99f424c30e5
     ap-southeast-2:
-      PASOEAMZNLINUX2: ami-0f226445cb78c05d8
+      PASOEAMZNLINUX2: ami-0f46a5aa8edd8b180
     ca-central-1:
-      PASOEAMZNLINUX2: ami-0289a0b4ad342adc5
+      PASOEAMZNLINUX2: ami-01f0138f7838af6d1
     eu-central-1:
-      PASOEAMZNLINUX2: ami-08e0f0207d1ab58b0
+      PASOEAMZNLINUX2: ami-05a91f57d7d663463
     eu-north-1:
-      PASOEAMZNLINUX2: ami-02c0d0e2eaf72abf4
+      PASOEAMZNLINUX2: ami-03c360fef860ec8cd
     eu-south-1:
-      PASOEAMZNLINUX2: ami-099fcf343ced32d87
+      PASOEAMZNLINUX2: ami-0280093f2af413081
     eu-west-1:
-      PASOEAMZNLINUX2: ami-0f40ef92d4e0987c6
+      PASOEAMZNLINUX2: ami-07a01733367728bba
     eu-west-2:
-      PASOEAMZNLINUX2: ami-0e079c6a6f04b774c
+      PASOEAMZNLINUX2: ami-0f90c230b8329768b
     eu-west-3:
-      PASOEAMZNLINUX2: ami-08f880de72910f409
+      PASOEAMZNLINUX2: ami-00c84a2a63725602f
     sa-east-1:
-      PASOEAMZNLINUX2: ami-05a9dbddb4865f867
+      PASOEAMZNLINUX2: ami-0df611972136ae3aa
     us-east-1:
-      PASOEAMZNLINUX2: ami-01509876f9479d692
+      PASOEAMZNLINUX2: ami-0d88ec6aa9ea043fd
     us-east-2:
-      PASOEAMZNLINUX2: ami-0e64ee530d5e7296d
+      PASOEAMZNLINUX2: ami-0767e8b0f2d5428ab
     us-west-1:
-      PASOEAMZNLINUX2: ami-08511b1e7eff4797d
+      PASOEAMZNLINUX2: ami-03027a767af4f2e5b
     us-west-2:
-      PASOEAMZNLINUX2: ami-0eb4dcdcc76f797f3
+      PASOEAMZNLINUX2: ami-08bdc372134f29820
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"


### PR DESCRIPTION
Updated quick start templates with 12.8.4 AMI IDs for both OpenEdge Database and PAS for OE AMIs